### PR TITLE
8.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This utility works on BIG-IP 14.1 and above, SSL Orchestrator 5.x and above.
   
   - Download the script onto the F5 BIG-IP:
 
-    `curl -k https://raw.githubusercontent.com/f5devcentral/sslo-o365-update/7.2.6/sslo_o365_update.py -o sslo_o365_update.py`
+    `curl -k https://raw.githubusercontent.com/f5devcentral/sslo-o365-update/8.0.0/sslo_o365_update.py -o sslo_o365_update.py`
 
   - Run the script with one of the following install options. Note that the install options create or replace an existing configuration, but **will not** by itself initiate an O365 URL fetch. To force a fetch on install, include the `--force` option.
 
@@ -160,10 +160,10 @@ The installed script creates a working directory (default: /shared/o365), a conf
 **O365 "Service Areas"** - O365 endpoints to consume, as described here: https://docs.microsoft.com/en-us/office365/enterprise/urls-and-ip-address-ranges. The "common" service area should remain enabled as it contains the bulk of the URLs.
 
     "service_areas":{
-        "common": True|False           -> Microsoft 365 Common and Office Online
-        "exchange": True|False         -> Exchange Online  
-        "sharepoint": True|False       -> SharePoint Online and OneDrive for Business
-        "skype": True|False            -> Skype for Business and Microsoft Teams
+        "common": true|false           -> Microsoft 365 Common and Office Online
+        "exchange": true|false         -> Exchange Online  
+        "sharepoint": true|false       -> SharePoint Online and OneDrive for Business
+        "skype": true|false            -> Skype for Business and Microsoft Teams
     }
 
 <br />
@@ -171,9 +171,9 @@ The installed script creates a working directory (default: /shared/o365), a conf
 **Outputs** - O365 Record objects to create   
 
     "outputs":{
-        "url_categories": True|False   -> Create URL categories
-        "url_datagroups": True|False   -> Create URL data groups
-        "ip_datagroups":  True|False   -> Create IPv4 data groups
+        "url_categories": true|false   -> Create URL categories
+        "url_datagroups": true|false   -> Create URL data groups
+        "ip_datagroups":  true|false   -> Create IPv4 data groups
     }
 
 <br />
@@ -181,17 +181,17 @@ The installed script creates a working directory (default: /shared/o365), a conf
 **O365 Categories** - create a single URL data set, and/or separate data sets for O365 Optimize/Default/Allow categories. The categories and recommended actions for each is described here: https://docs.microsoft.com/en-us/microsoft-365/enterprise/microsoft-365-network-connectivity-principles?view=o365-worldwide#BKMK_Categories
 
     "o365_categories":{                  
-        "all": True|False              -> Create a single date set containing all URLs (all categories)
-        "optimize: True|False          -> Create a data set containing O365 "Optimize" category URLs (note that the optimized URLs are in Exchange and "SharePoint service areas)
-        "default": True|False          -> Create a data set containing O365 "Allow" category URLs
-        "allow": True|False            -> Create a data set containing O365 "Default" category URLs
+        "all": true|false              -> Create a single date set containing all URLs (all categories)
+        "optimize: true|false          -> Create a data set containing O365 "Optimize" category URLs (note that the optimized URLs are in Exchange and "SharePoint service areas)
+        "default": true|false          -> Create a data set containing O365 "Allow" category URLs
+        "allow": true|false            -> Create a data set containing O365 "Default" category URLs
     }
 
 <br />
   
 **Required O365 endpoints to import** - O365 required endpoints or all endpoints. Importing all endpoints includes non-O365 URLs that one may not want to bypass (ex. www.youtube.com). It is recommended to leave this enabled/true (only download required URLs).
 
-    "only_required": True|False        -> false=import all URLs, true=Office 365 required only URLs
+    "only_required": true|false        -> false=import all URLs, true=Office 365 required only URLs
 
 <br />
   
@@ -274,24 +274,24 @@ The installed script creates a working directory (default: /shared/o365), a conf
 {
     "endpoint": "Worldwide",
     "service_areas": {
-        "common": True,
-        "exchange": True,
-        "sharepoint": True,
-        "skype": True
+        "common": true,
+        "exchange": true,
+        "sharepoint": true,
+        "skype": true
     },
     "outputs": {
-        "url_categories": True,
-        "url_datagroups": True,
-        "ip4_datagroups": True,
-        "ip6_datagroups": True
+        "url_categories": true,
+        "url_datagroups": true,
+        "ip4_datagroups": true,
+        "ip6_datagroups": true
     },
     "o365_categories": {
-        "all": True,
-        "optimize": True,
-        "default": True,
-        "allow": True
+        "all": true,
+        "optimize": true,
+        "default": true,
+        "allow": true
     },
-    "only_required": True,
+    "only_required": true,
     "excluded_urls": [
         ".symcd.com",
         ".symcb.com",

--- a/sslo_o365_update.py
+++ b/sslo_o365_update.py
@@ -13,6 +13,7 @@ version = "8.0.0"
 # >>> NOTE: THIS VERSION OF THE OFFICE 365 SCRIPT IS SUPPORTED BY SSL ORCHESTRATOR 5.0 OR HIGHER <<<
 #
 # Updated for SSL Orchestrator by Kevin Stewart, SSA, F5 Networks
+# Update 20250807 - to fix file operations during uninstall
 # Update 20250312 - to support updating with multiple endpoints (by Kevin Stewart)
 #   - Updated to add --endpoint option to be used with --uninstall, --full_uninstall, --printconfig, --force, and --search options
 #   - The install process creates categories and datagroups prefixed with the endpoint (ex. worldwide_Office365_Allow)
@@ -176,7 +177,7 @@ version = "8.0.0"
 # further testing or modification.
 #-----------------------------------------------------------------------
 
-import platform, fnmatch, uuid, os, pwd, re, json, time, datetime, sys, argparse, copy, ssl, hashlib
+import platform, fnmatch, uuid, os, pwd, re, json, time, datetime, sys, argparse, copy, ssl, hashlib, shutil
 
 if platform.python_version().startswith("2."):
     import commands as shell
@@ -1945,27 +1946,24 @@ class o365UrlManagement:
         # Delete the configuration iFile
         result = shell.getoutput("tmsh -a delete sys file ifile o365_update.app/" + endpoint + "_o365_config.json")
         print("..Configuration iFile deleted")
-        # Get a list of all the file paths that ends with .txt from in specified directory
-        fileList = os.listdir('/config/filestore/files_d/Common_d/ifile_d/')
-        pattern = "*" + endpoint + "_o365_config.json*"
-        # Iterate over the list of filepaths & remove each file.
-        for entry in fileList:
-            if fnmatch.fnmatch(entry, pattern):
-                try:
-                    os.remove('/config/filestore/files_d/Common_d/ifile_d/' + entry)
-                except:
-                    print("Error while deleting file : ", entry)
-        # Delete working directory files
-        try:
-            os.remove(self.work_directory + "/" + endpoint + "/guid.txt")
-        except:
-            pass
+        # Get a list of all the file paths that ends with .json from in specified directory
+        if os.path.isdir('/config/filestore/files_d/Common_d/ifile_d/'):
+            fileList = os.listdir('/config/filestore/files_d/Common_d/ifile_d/')
+            pattern = "*" + endpoint + "_o365_config.json*"
+            # Iterate over the list of filepaths & remove each file.
+            for entry in fileList:
+                if fnmatch.fnmatch(entry, pattern):
+                    try:
+                        os.remove('/config/filestore/files_d/Common_d/ifile_d/' + entry)
+                    except:
+                        print("Error while deleting file : ", entry)
 
+        # Delete working directory and files
         try:
-            os.remove(self.work_directory + "/" + endpoint + "/o365_version.txt")
+            shutil.rmtree(self.work_directory + "/" + endpoint)
         except:
             pass
-        print("..Configuration scratch files deleted")
+        print("..Endpoint scratch files and directory deleted")
 
         # Delete the cron config
         ## search /etc/cron.d/0hourly for matching (existing) line and replace


### PR DESCRIPTION
Updated README.md to fix version number in download instructions and fixed incorrect case for `true `and `false `in JSON examples.

Also, updated sslo_o365_update.py to address this issue on uninstall:

```python sslo_o365_update.py --full_uninstall --endpoint worldwide
..Uninstall in progress
..Configuration iFile deleted
Traceback (most recent call last):
  File "sslo_o365_update.py", line 2098, in <module>
    main()
  File "sslo_o365_update.py", line 2080, in main
    o365.script_uninstall('full')
  File "sslo_o365_update.py", line 1949, in script_uninstall
    fileList = os.listdir('/config/filestore/files_d/Common_d/ifile_d/')
OSError: [Errno 2] No such file or directory: '/config/filestore/files_d/Common_d/ifile_d/'
```

This error occurs when the script removes the last iFile from the system (line 1947). When the last iFile is removed from the system, the ifile_d directory is removed too. When `os.listdir('/config/filestore/files_d/Common_d/ifile_d/')` is subsequently run it throws an error because the directory does not exist. The script now checks to make sure this directory exists before attempting to list its contents.

Finally, instead of only removing the contents of the endpoint directory (ex. /tmp/o365/worldwide/guid.txt), the script removes the endpoint directory itself and all of its contents. I'm not sure if there is a reason to keep this directory in place (preserve log?) so unsure if this particular change is desired or not?